### PR TITLE
[DO NOT MERGE] Origami diffs

### DIFF
--- a/src/lz-evm-oapp-v2/access/OwnableOFT.sol
+++ b/src/lz-evm-oapp-v2/access/OwnableOFT.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+abstract contract OwnableOFT {
+    modifier onlyOFTOwner() virtual;
+}
+
+// @dev Example to use OpenZeppelin's Ownable:
+/**
+    import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+    contract OZOwnableOFT is OwnableOFT, Ownable {
+        modifier onlyOFTOwner() override {
+            _checkOwner();
+            _;
+        }
+    }
+*/
+
+// @dev Example to use Origami's OnlyElevatedAccess:
+/**
+    import { OrigamiElevatedAccess } from "contracts/common/access/OrigamiElevatedAccess.sol";
+
+    contract OrigamiOwnableOFT is OwnableOFT, OrigamiElevatedAccess {
+        modifier onlyOFTOwner() override {
+            if (!isElevatedAccess(msg.sender, msg.sig)) revert CommonEventsAndErrors.InvalidAccess();
+            _;
+        }
+    }
+*/

--- a/src/lz-evm-oapp-v2/oapp/OAppCore.sol
+++ b/src/lz-evm-oapp-v2/oapp/OAppCore.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.20;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { OwnableOFT } from "../access/OwnableOFT.sol";
 import { IOAppCore, ILayerZeroEndpointV2 } from "./interfaces/IOAppCore.sol";
 
 /**
  * @title OAppCore
  * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.
  */
-abstract contract OAppCore is IOAppCore, Ownable {
+abstract contract OAppCore is IOAppCore, OwnableOFT {
     // The LayerZero endpoint associated with the given OApp
     ILayerZeroEndpointV2 public immutable endpoint;
 
@@ -40,7 +40,7 @@ abstract contract OAppCore is IOAppCore, Ownable {
      * @dev Set this to bytes32(0) to remove the peer address.
      * @dev Peer is a bytes32 to accommodate non-evm chains.
      */
-    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {
+    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOFTOwner {
         _setPeer(_eid, _peer);
     }
 
@@ -77,7 +77,7 @@ abstract contract OAppCore is IOAppCore, Ownable {
      * @dev Only the owner/admin of the OApp can call this function.
      * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.
      */
-    function setDelegate(address _delegate) public onlyOwner {
+    function setDelegate(address _delegate) public onlyOFTOwner {
         endpoint.setDelegate(_delegate);
     }
 }

--- a/src/lz-evm-oapp-v2/oapp/libs/OAppOptionsType3.sol
+++ b/src/lz-evm-oapp-v2/oapp/libs/OAppOptionsType3.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.20;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { OwnableOFT } from "../../access/OwnableOFT.sol";
 import { IOAppOptionsType3, EnforcedOptionParam } from "../interfaces/IOAppOptionsType3.sol";
 
 /**
  * @title OAppOptionsType3
  * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.
  */
-abstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {
+abstract contract OAppOptionsType3 is IOAppOptionsType3, OwnableOFT {
     uint16 internal constant OPTION_TYPE_3 = 3;
 
     // @dev The "msgType" should be defined in the child contract.
@@ -25,7 +25,7 @@ abstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {
      * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay
      * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().
      */
-    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {
+    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOFTOwner {
         _setEnforcedOptions(_enforcedOptions);
     }
 

--- a/src/lz-evm-oapp-v2/oft/OFT.sol
+++ b/src/lz-evm-oapp-v2/oft/OFT.sol
@@ -11,18 +11,30 @@ import { IOFT, OFTCore } from "./OFTCore.sol";
  */
 abstract contract OFT is OFTCore, ERC20 {
     /**
+    * @dev Args to avoid stack-too-deep when dealing with OFTs
+    * both in build/tests and also code coverage checks
+    */
+    struct ConstructorArgs {
+        /// @dev The name of the OFT.
+        string name;
+
+        /// @dev The symbol of the OFT.
+        string symbol;
+        
+        /// @dev The LayerZero endpoint address.
+        address lzEndpoint;
+
+        /// @dev The delegate capable of making OApp configurations inside of the endpoint.
+        address delegate;
+    }
+
+    /**
      * @dev Constructor for the OFT contract.
-     * @param _name The name of the OFT.
-     * @param _symbol The symbol of the OFT.
-     * @param _lzEndpoint The LayerZero endpoint address.
-     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.
+     * @param _args The constructor arguments of the OFT.
      */
     constructor(
-        string memory _name,
-        string memory _symbol,
-        address _lzEndpoint,
-        address _delegate
-    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}
+        ConstructorArgs memory _args
+    ) ERC20(_args.name, _args.symbol) OFTCore(decimals(), _args.lzEndpoint, _args.delegate) {}
 
     /**
      * @dev Retrieves the address of the underlying ERC20 implementation.

--- a/src/lz-evm-oapp-v2/oft/OFTCore.sol
+++ b/src/lz-evm-oapp-v2/oft/OFTCore.sol
@@ -91,7 +91,7 @@ abstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3
      * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.
      * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.
      */
-    function setMsgInspector(address _msgInspector) public virtual onlyOwner {
+    function setMsgInspector(address _msgInspector) public virtual onlyOFTOwner {
         msgInspector = _msgInspector;
         emit MsgInspectorSet(_msgInspector);
     }

--- a/src/lz-evm-oapp-v2/precrime/OAppPreCrimeSimulator.sol
+++ b/src/lz-evm-oapp-v2/precrime/OAppPreCrimeSimulator.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.20;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { OwnableOFT } from "../access/OwnableOFT.sol";
 import { IPreCrime } from "./interfaces/IPreCrime.sol";
 import { IOAppPreCrimeSimulator, InboundPacket, Origin } from "./interfaces/IOAppPreCrimeSimulator.sol";
 
@@ -10,7 +10,7 @@ import { IOAppPreCrimeSimulator, InboundPacket, Origin } from "./interfaces/IOAp
  * @title OAppPreCrimeSimulator
  * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.
  */
-abstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {
+abstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, OwnableOFT {
     // The address of the preCrime implementation.
     address public preCrime;
 
@@ -29,7 +29,7 @@ abstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {
      * @dev Sets the preCrime contract address.
      * @param _preCrime The address of the preCrime contract.
      */
-    function setPreCrime(address _preCrime) public virtual onlyOwner {
+    function setPreCrime(address _preCrime) public virtual onlyOFTOwner {
         preCrime = _preCrime;
         emit PreCrimeSet(_preCrime);
     }

--- a/src/lz-evm-protocol-v2/MessagingComposer.sol
+++ b/src/lz-evm-protocol-v2/MessagingComposer.sol
@@ -58,6 +58,12 @@ abstract contract MessagingComposer is IMessagingComposer {
         emit ComposeDelivered(_from, _to, _guid, _index);
     }
 
+    // @note This causes a stack-too-depp
+    // LZ should use a struct to pass in this many parameters
+    // We don't need it for our (testing only) purposes however -- it's used in the EndpointV2 which
+    // we don't deploy -- not depended on by OFT or OFT Adapter
+
+    /*
     /// @param _from the address which sends the composed message
     /// @param _to the address which receives the composed message
     /// @param _guid the message guid
@@ -77,4 +83,5 @@ abstract contract MessagingComposer is IMessagingComposer {
     ) external {
         emit LzComposeAlert(_from, _to, msg.sender, _guid, _index, _gas, _value, _message, _extraData, _reason);
     }
+    */
 }

--- a/src/test-devtools-evm-foundry/mocks/DVNFeeLibMock.sol
+++ b/src/test-devtools-evm-foundry/mocks/DVNFeeLibMock.sol
@@ -55,7 +55,7 @@ contract DVNFeeLibMock is Ownable, IDVNFeeLib {
 
     mapping(uint32 dstEid => BlockTimeConfig) public dstBlockTimeConfigs;
 
-    constructor(uint32 _localEidV2, uint256 _nativeDecimalsRate) Ownable(msg.sender) {
+    constructor(uint32 _localEidV2, uint256 _nativeDecimalsRate) /* Ownable(msg.sender) */ {
         localEidV2 = _localEidV2;
         nativeDecimalsRate = _nativeDecimalsRate;
     }

--- a/src/test-devtools-evm-foundry/mocks/EndpointV2Mock.sol
+++ b/src/test-devtools-evm-foundry/mocks/EndpointV2Mock.sol
@@ -49,7 +49,9 @@ contract EndpointV2Mock is
 
     /// @param _eid the unique Endpoint Id for this deploy that all other Endpoints can use to send to it
     // @dev oz4/5 breaking change... Ownable constructor
-    constructor(uint32 _eid, address _owner) Ownable(_owner) MessagingChannel(_eid) {}
+    constructor(uint32 _eid, address _owner) /* Ownable(_owner) */ MessagingChannel(_eid) {
+        _transferOwnership(_owner);
+    }
 
     /// @dev MESSAGING STEP 0
     /// @notice This view function gives the application built on top of LayerZero the ability to requests a quote

--- a/src/test-devtools-evm-foundry/mocks/ExecutorFeeLibMock.sol
+++ b/src/test-devtools-evm-foundry/mocks/ExecutorFeeLibMock.sol
@@ -18,7 +18,7 @@ contract ExecutorFeeLibMock is Ownable, IExecutorFeeLib {
     uint32 private immutable localEidV2; // endpoint-v2 only, for read call
 
     // @dev oz4/5 breaking change... Ownable constructor
-    constructor(uint32 _localEidV2) Ownable(msg.sender) {
+    constructor(uint32 _localEidV2) /* Ownable(msg.sender) */ {
         localEidV2 = _localEidV2;
         nativeDecimalsRate = 1e18;
     }

--- a/src/test-devtools-evm-foundry/mocks/ExecutorMock.sol
+++ b/src/test-devtools-evm-foundry/mocks/ExecutorMock.sol
@@ -11,7 +11,7 @@ import { IExecutorFeeLib } from "@layerzerolabs/lz-evm-messagelib-v2/contracts/i
 // @dev oz4/5 breaking change... path
 import { WorkerMock as Worker } from "./WorkerMock.sol";
 // @dev oz4/5 breaking change... upgradeable reentrancy
-import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 contract ExecutorMock is Worker, ReentrancyGuard, IExecutor {
     using PacketV1Codec for bytes;

--- a/src/test-devtools-evm-foundry/mocks/MultiSigMock.sol
+++ b/src/test-devtools-evm-foundry/mocks/MultiSigMock.sol
@@ -89,7 +89,7 @@ abstract contract MultiSigMock {
         for (uint256 i = 0; i < quorum; i++) {
             bytes calldata signature = _signatures[i * 65:(i + 1) * 65];
             // @dev oz4/5 breaking change... return value from tryRecover
-            (address currentSigner, ECDSA.RecoverError error /*bytes32(signature.length)*/, ) = ECDSA.tryRecover(
+            (address currentSigner, ECDSA.RecoverError error /*, bytes32(signature.length)*/ ) = ECDSA.tryRecover(
                 messageDigest,
                 signature
             );

--- a/src/test-devtools-evm-foundry/mocks/PriceFeedMock.sol
+++ b/src/test-devtools-evm-foundry/mocks/PriceFeedMock.sol
@@ -31,7 +31,7 @@ contract PriceFeedMock is ILayerZeroPriceFeed, Ownable {
     // ============================ Constructor ===================================
 
     // @dev oz4/5 breaking change... Ownable constructor
-    constructor(address _priceUpdater) Ownable(msg.sender) {
+    constructor(address _priceUpdater) /* Ownable(msg.sender) */ {
         priceUpdater[_priceUpdater] = true;
         PRICE_RATIO_DENOMINATOR = 1e20;
         ARBITRUM_COMPRESSION_PERCENT = 47;

--- a/src/test-devtools-evm-foundry/mocks/ReadLib1002Mock.sol
+++ b/src/test-devtools-evm-foundry/mocks/ReadLib1002Mock.sol
@@ -69,7 +69,7 @@ contract ReadLib1002Mock is ISendLib, ERC165, ReadLibBase, MessageLibBase {
         address _endpoint,
         uint256 _treasuryGasLimit,
         uint256 _treasuryGasForFeeCap
-    ) Ownable(msg.sender) MessageLibBase(_endpoint, ILayerZeroEndpointV2(_endpoint).eid()) {
+    ) /* Ownable(msg.sender) */ MessageLibBase(_endpoint, ILayerZeroEndpointV2(_endpoint).eid()) {
         treasuryGasLimit = _treasuryGasLimit;
         treasuryNativeFeeCap = _treasuryGasForFeeCap;
         testHelper = TestHelperOz5(_verifyHelper);

--- a/src/test-devtools-evm-foundry/mocks/ReceiveUln302Mock.sol
+++ b/src/test-devtools-evm-foundry/mocks/ReceiveUln302Mock.sol
@@ -21,7 +21,7 @@ contract ReceiveUln302Mock is IReceiveUlnE2, ReceiveUlnBase, ReceiveLibBaseE2 {
     error LZ_ULN_InvalidConfigType(uint32 configType);
 
     // @dev oz4/5 breaking change... Ownable constructor
-    constructor(address _endpoint) Ownable(msg.sender) ReceiveLibBaseE2(_endpoint) {}
+    constructor(address _endpoint) /* Ownable(msg.sender) */ ReceiveLibBaseE2(_endpoint) {}
 
     function supportsInterface(bytes4 _interfaceId) public view override returns (bool) {
         return _interfaceId == type(IReceiveUlnE2).interfaceId || super.supportsInterface(_interfaceId);

--- a/src/test-devtools-evm-foundry/mocks/SendUln302Mock.sol
+++ b/src/test-devtools-evm-foundry/mocks/SendUln302Mock.sol
@@ -31,7 +31,7 @@ contract SendUln302Mock is SendUlnBase, SendLibBaseE2 {
         address _endpoint,
         uint256 _treasuryGasCap,
         uint256 _treasuryGasForFeeCap
-    ) Ownable(msg.sender) SendLibBaseE2(_endpoint, _treasuryGasCap, _treasuryGasForFeeCap) {
+    ) /* Ownable(msg.sender) */ SendLibBaseE2(_endpoint, _treasuryGasCap, _treasuryGasForFeeCap) {
         testHelper = TestHelperOz5(_verifyHelper);
     }
 

--- a/src/test-devtools-evm-foundry/mocks/SimpleMessageLibMock.sol
+++ b/src/test-devtools-evm-foundry/mocks/SimpleMessageLibMock.sol
@@ -50,7 +50,7 @@ contract SimpleMessageLibMock is Ownable, ERC165 {
     }
 
     // @dev oz4/5 breaking change... Ownable constructor
-    constructor(address payable _verifyHelper, address _endpoint) Ownable(msg.sender) {
+    constructor(address payable _verifyHelper, address _endpoint) /* Ownable(msg.sender) */ {
         testHelper = TestHelperOz5(_verifyHelper);
         endpoint = _endpoint;
         treasury = address(0x0);

--- a/src/test-devtools-evm-foundry/mocks/WorkerMock.sol
+++ b/src/test-devtools-evm-foundry/mocks/WorkerMock.sol
@@ -141,23 +141,21 @@ abstract contract WorkerMock is AccessControl, Pausable, IWorker {
     /// @dev overrides AccessControl to allow for counting of allowlistSize
     /// @param _role role to grant
     /// @param _account address to grant role to
-    function _grantRole(bytes32 _role, address _account) internal override returns (bool) {
+    function _grantRole(bytes32 _role, address _account) internal override {
         if (_role == ALLOWLIST && !hasRole(_role, _account)) {
             ++allowlistSize;
         }
         super._grantRole(_role, _account);
-        return true;
     }
 
     /// @dev overrides AccessControl to allow for counting of allowlistSize
     /// @param _role role to revoke
     /// @param _account address to revoke role from
-    function _revokeRole(bytes32 _role, address _account) internal override returns (bool) {
+    function _revokeRole(bytes32 _role, address _account) internal override {
         if (_role == ALLOWLIST && hasRole(_role, _account)) {
             --allowlistSize;
         }
         super._revokeRole(_role, _account);
-        return true;
     }
 
     /// @dev overrides AccessControl to disable renouncing of roles


### PR DESCRIPTION
See: [README](https://github.com/TempleDAO/origami-layerzero) for the base contracts pulled into here.

* Commit 1: https://github.com/TempleDAO/origami-layerzero/pull/1/commits/6f4d0a5fc3ea06e9357762a0ddcb0a64f26a743b
  * Pull out OFT constructor parameters into a struct to avoid stack-too-deep in client code
  * Update Ownable etc for OpenZeppelin v4.* -- Origami's still using it for now (on the list to update)
* Commit 2: https://github.com/TempleDAO/origami-layerzero/pull/1/commits/03c96aaff9c00d2d686dae796013fe3af5961d0e
  * Add a BYO model for Ownership of OFT and OFTAdapter contract. This allows the client code to use OpenZeppelin's `Ownable`, but in the Origami case it is to use `OrigamiElevatedAccess`
* Commit 3: https://github.com/TempleDAO/origami-layerzero/pull/1/commits/f159b1da435bc7ba3ef35a669ae2f87734289b0b
  * Further stack-too-deep errors come up in testing or especially `forge coverage` where `--ir-minimum` is used. Commenting out this function (which is unused in tests and our contract deployments) fixes this.
  * In an ideal world - LZ would use a struct for these arguments.